### PR TITLE
Log of Exception message in getPhotosInPhotoset

### DIFF
--- a/code/services/FlickrService.php
+++ b/code/services/FlickrService.php
@@ -166,9 +166,10 @@ class FlickrService extends RestfulService {
 		} catch(Exception $e) {
 			SS_Log::log(
 				sprintf(
-					"Couldn't retrieve Flickr photos in photoset '%s' for optional user '%s'",
+					"Couldn't retrieve Flickr photos in photoset '%s' for optional user '%s'. Message: %s",
 					$photosetId,
-					$userId
+					$userId,
+					$e->getMessage()
 				),
 				SS_Log::ERR
 			);


### PR DESCRIPTION
Only added the Exception message in the log. All other retrieving functions log that message already.
